### PR TITLE
"SocialBlueprint" -> "cls" in "create_bp"

### DIFF
--- a/src/flask_social_blueprint/core.py
+++ b/src/flask_social_blueprint/core.py
@@ -78,7 +78,7 @@ class SocialBlueprint(Blueprint):
 
     @classmethod
     def create_bp(cls, name, connection_adapter, providers, *args, **kwargs):
-        bp = SocialBlueprint(name, __name__, connection_adapter, providers, *args, **kwargs)
+        bp = cls(name, __name__, connection_adapter, providers, *args, **kwargs)
         bp.route('/login/<provider>', endpoint="login")(bp.authenticate)
         bp.route('/callback/<provider>', endpoint="callback")(bp.callback)
         return bp


### PR DESCRIPTION
If you extend SocialBlueprint class, you should necessarily override "create_bp" method because "SocialBlueprint" is hardcoded in it. After this commit it is not required to do this anymore