### PR TITLE
Facebook do not provide user's email

### DIFF
--- a/src/flask_social_blueprint/providers.py
+++ b/src/flask_social_blueprint/providers.py
@@ -136,7 +136,7 @@ class Facebook(BaseProvider):
         import facebook
 
         graph = facebook.GraphAPI(access_token)
-        profile = graph.get_object("me")
+        profile = graph.get_object("me?fields=email")
         profile_id = profile['id']
         data = {
             "provider": "Facebook",


### PR DESCRIPTION
Facebook class in 'providers.py' do not provide user's email
I think this problem based on Facebook Graph Api versions.
Graph api versions is upgraded to 2.4.
They're not provide email exactly. 
Graph API ver 2.3
curl -i -X GET \
"https://graph.facebook.com/v2.3/me?access_token=..." // can get email
Graph API ver 2.4.
curl -i -X GET \
"https://graph.facebook.com/v2.4/me?access_token=..." // cannot get email

Therefore, I think you should change 'facebook' class in providers.py.
just 
'profile = graph.get_object("me?fields=email")'

I think all libraries should be changed based on flask-oauth.
Thank you!