### PR TITLE
proper fallback if the exception doesn't have any message attribute

### DIFF
--- a/src/flask_social_blueprint/core.py
+++ b/src/flask_social_blueprint/core.py
@@ -56,7 +56,7 @@ class SocialBlueprint(Blueprint):
             connection = self.create_connection(profile, provider)
         except Exception as ex:
             logging.warn(ex, exc_info=True)
-            do_flash(_("Could not register: {}").format(ex.message), "warning")
+            do_flash(_("Could not register: {}").format(getattr(ex, "message", ex)), "warning")
             return self.login_failed_redirect(profile, provider)
 
         return self.login_connection(connection, profile, provider)


### PR DESCRIPTION

![screen shot 2015-09-13 at 17 12 57](https://cloud.githubusercontent.com/assets/40496/9837298/b565ceae-5a3a-11e5-999b-0c192101209a.png)
 
Currently fails violently, although that should generally be ok...