### PR TITLE
Facebook Graph API Fixes

### DIFF
--- a/src/flask_social_blueprint/providers.py
+++ b/src/flask_social_blueprint/providers.py
@@ -136,7 +136,7 @@ class Facebook(BaseProvider):
         import facebook
 
         graph = facebook.GraphAPI(access_token)
-        profile = graph.get_object("me?fields=email")
+        profile = graph.get_object("me", fields="email")
         profile_id = profile['id']
         data = {
             "provider": "Facebook",


### PR DESCRIPTION
This addresses #14 - looks like the latest Facebook python client likes to parse its own querystring from kwargs. Pretty simple change.